### PR TITLE
Attempt to fix rendering of included files

### DIFF
--- a/content/en/docs/02/pipeline_structure.md
+++ b/content/en/docs/02/pipeline_structure.md
@@ -44,7 +44,7 @@ Create a new file `.gitlab-ci.yml` and add the following content to the it. It m
 vim .gitlab-ci.yml
 ```
 
-{{< highlight yaml >}}{{< readfile file="manifests/02.0/.gitlab-ci.yml" >}}{{< /highlight >}}
+{{< readfile file="manifests/02.0/.gitlab-ci.yml" code="true" lang="yaml" >}}
 
 {{% alert title="Info" color="primary" %}}
 You can also use your favorite editor instead of `vim`.

--- a/content/en/docs/06/testing.md
+++ b/content/en/docs/06/testing.md
@@ -22,7 +22,7 @@ Create a new job inside `.gitlab-ci.yml` with the following configuration:
 
 This is how the new job `test_application` is defined in the `.gitlab-ci.yml`.
 
-{{< highlight yaml >}}{{< readfile file="manifests/06.0/test-job-base.yml" >}}{{< /highlight >}}
+{{< readfile file="manifests/06.0/test-job-base.yml" code="true" lang="yaml" >}}
 
 {{% /details %}}
 
@@ -63,7 +63,7 @@ The job can be extended with an `artifacts` configuration. Dev's know that the u
 
 This is the configuration that makes GitLab CI/CD store the test results.
 
-{{< highlight yaml >}}{{< readfile file="manifests/06.0/test-job-reports.yml" >}}{{< /highlight >}}
+{{< readfile file="manifests/06.0/test-job-reports.yml" code="true" lang="yaml" >}}
 
 See also the official documentation: [Unit test reports](https://docs.gitlab.com/ee/ci/unit_test_reports.html#unit-test-reports)
 


### PR DESCRIPTION
Including files in labs using the highlight and readfile functions didn't work for our other trainings anymore. We were able to fix this by removing the highlight function (as suggested in this PR). However, you make extensive use of highlighting specific lines to which I don't see a quick solution.

Maybe this PR helps you find a solutions faster.